### PR TITLE
Hot-Fix: count_ssm_by_region.R

### DIFF
--- a/R/count_ssm_by_region.R
+++ b/R/count_ssm_by_region.R
@@ -17,16 +17,10 @@
 #'
 #' @examples
 #' #define a region.
-#' my_region = gene_to_region(gene_symbol = "MYC",
-#'                            return_as = "region")
-#'
-#' #get meta data and subset
-#' my_metadata = GAMBLR.data::gambl_metadata
-#' fl_metadata = dplyr::filter(my_metadata, pathology == "FL")
+#' my_region = gene_to_region(gene_symbol = "MYC", return_as = "region")
 #'
 #' #count SSMs for the selected sample subset and defined region.
-#' fl_ssm_counts_myc = count_ssm_by_region(region = my_region,
-#'                                        these_samples_metadata = fl_metadata)
+#' count_ssm_by_region(region = my_region)
 #'
 count_ssm_by_region = function(region,
                                chromosome,
@@ -40,16 +34,24 @@ count_ssm_by_region = function(region,
   if(missing(these_samples_metadata)){
     these_samples_metadata = GAMBLR.helpers::handle_metadata(this_seq_type = seq_type)
   }
+  
   if(!missing(all_mutations_in_these_regions)){
     # function was provided the mutations already so we just need to subset it to the region of interest
-
-    region_muts = dplyr::filter(all_mutations_in_these_regions,Start_Position >= start, Start_Position < end)
+    region_muts = dplyr::filter(all_mutations_in_these_regions,
+                                Start_Position >= start, 
+                                Start_Position < end)
   }else if(missing(region)){
-    region_muts = GAMBLR.helpers::handle_ssm_by_region(chromosome=chromosome,qstart=start,qend=end,streamlined = TRUE)
+    region_muts = get_ssm_by_region(chromosome = chromosome,
+                                    qstart = start,
+                                    qend = end,
+                                    streamlined = TRUE)
   }else{
-    region_muts = GAMBLR.helpers::handle_ssm_by_region(region=region,streamlined = TRUE)
+    region_muts = get_ssm_by_region(region = region, 
+                                    streamlined = TRUE)
   }
+  
   keep_muts = dplyr::filter(region_muts,Tumor_Sample_Barcode %in% these_samples_metadata$Tumor_Sample_Barcode)
+  
   if(missing(count_by)){
     #count everything even if some mutations are from the same patient
     return(nrow(keep_muts))

--- a/man/count_ssm_by_region.Rd
+++ b/man/count_ssm_by_region.Rd
@@ -37,15 +37,9 @@ Count the variants in a region with a variety of filtering options.
 }
 \examples{
 #define a region.
-my_region = gene_to_region(gene_symbol = "MYC",
-                           return_as = "region")
-
-#get meta data and subset
-my_metadata = GAMBLR.data::gambl_metadata
-fl_metadata = dplyr::filter(my_metadata, pathology == "FL")
+my_region = gene_to_region(gene_symbol = "MYC", return_as = "region")
 
 #count SSMs for the selected sample subset and defined region.
-fl_ssm_counts_myc = count_ssm_by_region(region = my_region,
-                                       these_samples_metadata = fl_metadata)
+count_ssm_by_region(region = my_region)
 
 }


### PR DESCRIPTION
At the dawn of the GAMBLR migration, this function was updated to call a newly added helper function (now obsolete and removed in [this](https://github.com/morinlab/GAMBLR.helpers/pull/14) PR) called `handle_ssm_by_region`. 

This helper function was developed to allow non-GSC users to use familiar core GAMBLR.results core functionalities, in a slightly different way. The user would always have to provide an incoming MAF (rather than having the function retrieve it in the first place). This strategy has since been abandoned. Instead, we now have duplicated functions (in GAMBLR.results with GSC access and GAMBLR.data for non-GSC usage) to solve this issue. 

This means that this function needs to have the internal call of `handle_ssm_by_region` updated to `get_ssm_by_region` to perform in the desired way. Other edits to this function includes, examples simplification and code-formatting.

This fix resolves the issue reported [here](https://github.com/morinlab/GAMBLR.utils/issues/13).