### PR TITLE
Improvement to region_to_gene, when no genes are found within the specified region

### DIFF
--- a/R/region_to_gene.R
+++ b/R/region_to_gene.R
@@ -2,31 +2,51 @@
 #'
 #' @description Return genes residing in defined region(s).
 #'
-#' @details This function takes a region as a vector of characters, or a data frame with of regions (e.g output from `gene_to_region(return_as="df")`).
+#' @details This function takes a region as a vector of characters, or a data frame with of regions (e.g output from `gene_to_region(return_as = "df")`).
 #' and returns the genes residing withing the specified region. For the other way around (i.e gene to regions, refer to [GAMBLR.utils::gene_to_region]).
+#' If the user provides a region as a vector of characters there is the option to set `return_empty = TRUE`. 
+#' This forces the function to return an empty data frame when there are no genes found within the specified region for the selected projection.
+#' Note, if the user provides a data frame with regions, any regions that no genes are found for will be excluded automatically in the the returned object.
 #'
 #' @param region Regions to intersect genes with, this can be either a data frame with regions sorted in the following columns; chromosome, start, end. Or it can be a character vector in "region" format, i.e chromosome:start-end.
 #' @param gene_format Parameter for specifying the format of returned genes, default is "hugo", other acceptable inputs are "ensembl".
-#' @param genome_build Reference genome build.
+#' @param genome_build Reference genome build. Default is grch37.
+#' @param verbose Set to TRUE for noisier output to the console. Useful or debugging purposes. Default is FALSE.
+#' @param return_empty Set to TRUE to force returning an empty data frame when no genes are found within the specified region for the selected projection. 
+#' This only applies when the function is given a region as a vector of characters. See function documentation for more information. Default is FALSE.
 #'
-#' @return A data frame with gene(s) that are residing in the specified region(s).
+#' @return A data frame with columns detailing the gene/region.
 #'
 #' @rawNamespace import(data.table, except = c("last", "first", "between", "transpose"))
 #' @import dplyr
 #' @export
 #'
 #' @examples
-#' myc_region = gene_to_region(gene_symbol = "MYC",
-#'                             genome_build = "grch37",
-#'                             return_as = "df")
-#'
-#' region = region_to_gene(region = myc_region,
-#'                         gene_format = "hugo",
-#'                         genome_build = "grch37")
+#' #get a region, used for input in Example 1
+#' genes_of_interest = gene_to_region(gene_symbol = c("MYC", "BCL2"),
+#'                                    genome_build = "grch37",
+#'                                    return_as = "df")
+#' 
+#' #Example 1 - Use a data frame with 1 region:
+#' in_my_region = region_to_gene(region = genes_of_interest)
+#'                         
+#' #Example 2 - Use a region specified as a vector of characters:
+#' in_my_region = region_to_gene(region = "chr8:127735433-127742951", 
+#'                               genome_build = "hg38", 
+#'                               gene_format = "ensembl", 
+#'                               verbose = TRUE)
+#'                               
+#' #Example 3 - Use a region with no genes in it, and return the empty data frame anyway:
+#' in_my_region = region_to_gene(region = "chr14:105862865-105863058",
+#'                               genome_build = "hg38", 
+#'                               verbose = TRUE, 
+#'                               return_empty = TRUE)
 #'
 region_to_gene = function(region,
                           gene_format = "hugo",
-                          genome_build = "grch37"){
+                          genome_build = "grch37",
+                          verbose = TRUE,
+                          return_empty = FALSE){
 
   #set mart based on selected genome projection
   if(genome_build == "grch37"){
@@ -84,16 +104,31 @@ region_to_gene = function(region,
   }else if(gene_format == "ensembl"){
     genes = dplyr::select(inter_df, chromosome, start, end, ensembl_gene_id, region_start, region_end)
   }
+  
+  genes = as.data.frame(genes) %>%
+    dplyr::arrange(chromosome, start) %>%
+    distinct(.keep_all = TRUE)
+
+  #add checks for 0 genes in the region
+  if(nrow(genes) == 0){
+    if(return_empty){
+      if(verbose){
+        message("No genes found within the specified region, an empty data frame will be returned")
+      }
+      return(genes) 
+    }else{
+      stop(paste0("The specified region does not overlap with any genes in the selected projection.", "\n", 
+                "  If you want the empty data frame back, run this function with `return_empty = TRUE`"))
+    }
+  }
 
   #paste chr in chromosome column, if not there
   if(!str_detect(genes$chromosome[1], "chr")){
     genes = mutate(genes, chromosome = paste0("chr", chromosome))}
 
-  genes = as.data.frame(genes) %>%
-    dplyr::arrange(chromosome, start) %>%
-    distinct(.keep_all = TRUE)
-
-  message(paste0(nrow(genes), " gene(s) returned for ", nrow(region), " region(s)"))
+  if(verbose){
+    message(paste0(nrow(genes), " gene(s) returned for ", nrow(region), " region(s)")) 
+  }
 
   return(genes)
 }

--- a/man/region_to_gene.Rd
+++ b/man/region_to_gene.Rd
@@ -4,32 +4,58 @@
 \alias{region_to_gene}
 \title{Region To Gene.}
 \usage{
-region_to_gene(region, gene_format = "hugo", genome_build = "grch37")
+region_to_gene(
+  region,
+  gene_format = "hugo",
+  genome_build = "grch37",
+  verbose = TRUE,
+  return_empty = FALSE
+)
 }
 \arguments{
 \item{region}{Regions to intersect genes with, this can be either a data frame with regions sorted in the following columns; chromosome, start, end. Or it can be a character vector in "region" format, i.e chromosome:start-end.}
 
 \item{gene_format}{Parameter for specifying the format of returned genes, default is "hugo", other acceptable inputs are "ensembl".}
 
-\item{genome_build}{Reference genome build.}
+\item{genome_build}{Reference genome build. Default is grch37.}
+
+\item{verbose}{Set to TRUE for noisier output to the console. Useful or debugging purposes. Default is FALSE.}
+
+\item{return_empty}{Set to TRUE to force returning an empty data frame when no genes are found within the specified region for the selected projection.
+This only applies when the function is given a region as a vector of characters. See function documentation for more information. Default is FALSE.}
 }
 \value{
-A data frame with gene(s) that are residing in the specified region(s).
+A data frame with columns detailing the gene/region.
 }
 \description{
 Return genes residing in defined region(s).
 }
 \details{
-This function takes a region as a vector of characters, or a data frame with of regions (e.g output from \code{gene_to_region(return_as="df")}).
+This function takes a region as a vector of characters, or a data frame with of regions (e.g output from \code{gene_to_region(return_as = "df")}).
 and returns the genes residing withing the specified region. For the other way around (i.e gene to regions, refer to \link{gene_to_region}).
+If the user provides a region as a vector of characters there is the option to set \code{return_empty = TRUE}.
+This forces the function to return an empty data frame when there are no genes found within the specified region for the selected projection.
+Note, if the user provides a data frame with regions, any regions that no genes are found for will be excluded automatically in the the returned object.
 }
 \examples{
-myc_region = gene_to_region(gene_symbol = "MYC",
-                            genome_build = "grch37",
-                            return_as = "df")
+#get a region, used for input in Example 1
+genes_of_interest = gene_to_region(gene_symbol = c("MYC", "BCL2"),
+                                   genome_build = "grch37",
+                                   return_as = "df")
 
-region = region_to_gene(region = myc_region,
-                        gene_format = "hugo",
-                        genome_build = "grch37")
+#Example 1 - Use a data frame with 1 region:
+in_my_region = region_to_gene(region = genes_of_interest)
+                        
+#Example 2 - Use a region specified as a vector of characters:
+in_my_region = region_to_gene(region = "chr8:127735433-127742951", 
+                              genome_build = "hg38", 
+                              gene_format = "ensembl", 
+                              verbose = TRUE)
+                              
+#Example 3 - Use a region with no genes in it, and return the empty data frame anyway:
+in_my_region = region_to_gene(region = "chr14:105862865-105863058",
+                              genome_build = "hg38", 
+                              verbose = TRUE, 
+                              return_empty = TRUE)
 
 }


### PR DESCRIPTION
This PR introduces an enhancement to `region_to_gene`. If the user calls this function with a region specified in the "region" format (chromosome:start-end), the user now has the option to return the empty data frame if no genes are found within the specified region. 

Other improvements to this function include documentation updates and improved examples. 

Note, if, the user calls this function with a data frame with regions, the function always ignores any regions that no genes are found within. 

This PR addresses the issue reported [here ](https://github.com/morinlab/GAMBLR/issues/246)

```
> #load utils
> library(GAMBLR.utils)
>
> #get regions, used for input in Example 1
> genes_of_interest = gene_to_region(gene_symbol = c("MYC", "BCL2"),
+                                    genome_build = "grch37",
+                                    return_as = "df")
2 region(s) returned for 2 gene(s)

> #Example 1 - Use a data frame with 1 region:
> in_my_region = region_to_gene(region = genes_of_interest)
5 gene(s) returned for 2 region(s)
> in_my_region
  chromosome     start       end hugo_symbol region_start region_end
1      chr18  60790579  60987361        BCL2     60790579   60987361
2      chr18  60818347  60818553        <NA>     60790579   60987361
3      chr18  60861822  60861898        <NA>     60790579   60987361
4      chr18  60981035  60981315        <NA>     60790579   60987361
5       chr8 128747680 128753674         MYC    128747680  128753674

> #Example 2 - Use a region specified in region format:
> in_my_region = region_to_gene(region = "chr8:127735433-127742951", 
+                               genome_build = "hg38", 
+                               gene_format = "ensembl", 
+                               verbose = TRUE)
2 gene(s) returned for 1 region(s)
> in_my_region
  chromosome     start       end ensembl_gene_id region_start region_end
1       chr8 127686342 127738987 ENSG00000249375    127735433  127742951
2       chr8 127735433 127742951 ENSG00000136997    127735433  127742951

> #Example 3 - Use a region with no genes in it, and return the empty data frame anyway:
> in_my_region = region_to_gene(region = "chr14:105862865-105863058",
+                               genome_build = "hg38", 
+                               verbose = TRUE, 
+                               return_empty = TRUE)
No genes found within the specified region, an empty data frame will be returned
> in_my_region
[1] chromosome   start        end          hugo_symbol  region_start region_end  
<0 rows> (or 0-length row.names)
> 
```