### PR TITLE
Fix annotate_sv and some function examples

### DIFF
--- a/R/cnvKompare.R
+++ b/R/cnvKompare.R
@@ -33,6 +33,8 @@
 #' @export
 #'
 #' @examples
+#' library(GAMBLR.data)
+#' 
 #' #get segs for comparison
 #' my_segs = get_sample_cn_segments(these_sample_ids = c("02-13135T", "04-28140T"))
 #'

--- a/R/count_ssm_by_region.R
+++ b/R/count_ssm_by_region.R
@@ -16,6 +16,8 @@
 #' @export
 #'
 #' @examples
+#' library(GAMBLR.data)
+#' 
 #' #define a region.
 #' my_region = gene_to_region(gene_symbol = "MYC", return_as = "region")
 #'

--- a/R/supplement_maf.R
+++ b/R/supplement_maf.R
@@ -13,14 +13,14 @@
 #' @export
 #'
 #' @examples
-#' my_metadata = GAMBLR.data::gambl_metadata
-#' reddy_meta = dplyr::filter(my_metadata, cohort=="dlbcl_reddy")
-#'
-#' small_maf = dplyr::filter(GAMBLR.data::sample_data$grch37$maf,
-#'  Tumor_Sample_Barcode %in% reddy_meta$Tumor_Sample_Barcode)
-#'
+#' library(GAMBLR.data)
+#' 
+#' reddy_meta = get_gambl_metadata()
+#' reddy_meta = dplyr::filter(reddy_meta, cohort=="dlbcl_reddy")
+#' 
+#' small_maf = get_ssm_by_samples(these_samples_metadata = reddy_meta)
 #' small_maf = dplyr::filter(small_maf, Hugo_Symbol == "MYC")
-#'
+#' 
 #' complete_maf = supplement_maf(incoming_maf = small_maf,
 #'                               these_samples_metadata = reddy_meta)
 #'

--- a/R/supplement_maf.R
+++ b/R/supplement_maf.R
@@ -16,8 +16,8 @@
 #' my_metadata = GAMBLR.data::gambl_metadata
 #' reddy_meta = dplyr::filter(my_metadata, cohort=="dlbcl_reddy")
 #'
-#' small_maf = GAMBLR.data::sample_dat$maf$grch37 %>%
-#'  dplyr::filter(Tumor_Sample_Barcode %in% reddy_meta$Tumor_Sample_Barcode)
+#' small_maf = dplyr::filter(GAMBLR.data::sample_data$grch37$maf,
+#'  Tumor_Sample_Barcode %in% reddy_meta$Tumor_Sample_Barcode)
 #'
 #' small_maf = dplyr::filter(small_maf, Hugo_Symbol == "MYC")
 #'

--- a/man/cnvKompare.Rd
+++ b/man/cnvKompare.Rd
@@ -66,6 +66,8 @@ Finally, the time series plot of CNV log ratios will be returned for all lymphom
 it to a panel of genes of interest.
 }
 \examples{
+library(GAMBLR.data)
+
 #get segs for comparison
 my_segs = get_sample_cn_segments(these_sample_ids = c("02-13135T", "04-28140T"))
 

--- a/man/count_ssm_by_region.Rd
+++ b/man/count_ssm_by_region.Rd
@@ -36,6 +36,8 @@ count_ssm_by_region(
 Count the variants in a region with a variety of filtering options.
 }
 \examples{
+library(GAMBLR.data)
+
 #define a region.
 my_region = gene_to_region(gene_symbol = "MYC", return_as = "region")
 

--- a/man/supplement_maf.Rd
+++ b/man/supplement_maf.Rd
@@ -25,8 +25,8 @@ give the function a filtered metadata table (with the sample IDs of interest) to
 my_metadata = GAMBLR.data::gambl_metadata
 reddy_meta = dplyr::filter(my_metadata, cohort=="dlbcl_reddy")
 
-small_maf = GAMBLR.data::sample_dat$maf$grch37 \%>\%
- dplyr::filter(Tumor_Sample_Barcode \%in\% reddy_meta$Tumor_Sample_Barcode)
+small_maf = dplyr::filter(GAMBLR.data::sample_data$grch37$maf,
+ Tumor_Sample_Barcode \%in\% reddy_meta$Tumor_Sample_Barcode)
 
 small_maf = dplyr::filter(small_maf, Hugo_Symbol == "MYC")
 

--- a/man/supplement_maf.Rd
+++ b/man/supplement_maf.Rd
@@ -22,12 +22,12 @@ Specify the initial MAF with \code{incoming_maf} (to be supplemented with missin
 give the function a filtered metadata table (with the sample IDs of interest) to the \code{these_samples_metadata}.
 }
 \examples{
-my_metadata = GAMBLR.data::gambl_metadata
-reddy_meta = dplyr::filter(my_metadata, cohort=="dlbcl_reddy")
+library(GAMBLR.data)
 
-small_maf = dplyr::filter(GAMBLR.data::sample_data$grch37$maf,
- Tumor_Sample_Barcode \%in\% reddy_meta$Tumor_Sample_Barcode)
+reddy_meta = get_gambl_metadata()
+reddy_meta = dplyr::filter(reddy_meta, cohort=="dlbcl_reddy")
 
+small_maf = get_ssm_by_samples(these_samples_metadata = reddy_meta)
 small_maf = dplyr::filter(small_maf, Hugo_Symbol == "MYC")
 
 complete_maf = supplement_maf(incoming_maf = small_maf,


### PR DESCRIPTION
This used to return an error. Now it's fixed. 
```
> sv_df = get_manta_sv(these_sample_ids = "DOHH-2", projection = "hg38")
Using the bundled Manta SV (.bedpe) calls in GAMBLR.data...
Using the bundled metadata in GAMBLR.data...
> annotated_entrez = annotate_sv(sv_data = sv_df,
+                                with_chr_prefix = TRUE,
+                                collapse_redundant = FALSE,
+                                return_as = "bedpe_entrez", 
+                                genome_build = "hg38")
> annotated_entrez
   chrom1    start1      end1 chrom2    start2      end2 name score strand1 strand2 tumour_sample_id
1:   chr8 127735954 127735954  chr14 105647949 105647949    .    84       +       -           DOHH-2
2:   chr8 127735958 127735959  chr14 105647945 105647946    .    83       -       +           DOHH-2
3:  chr14 105863255 105863255  chr18  63126264  63126264    .   103       +       -           DOHH-2
4:  chr14 105913232 105913232  chr18  63126259  63126259    .    91       -       +           DOHH-2
   gene entrez partner   fusion
1:  MYC   4609     IGH  IGH-MYC
2:  MYC   4609     IGH  IGH-MYC
3: BCL2    596     IGH IGH-BCL2
4: BCL2    596     IGH IGH-BCL2
```

And this continues working:
```
> sv_df = get_manta_sv(projection = "hg38")
Using the bundled Manta SV (.bedpe) calls in GAMBLR.data...
Using the bundled metadata in GAMBLR.data...
> annotated_entrez = annotate_sv(sv_data = sv_df,
+                                with_chr_prefix = F,
+                                collapse_redundant = FALSE,
+                                return_as = "bedpe_entrez", 
+                                genome_build = "hg38")
> annotated_entrez
      chrom1    start1      end1 chrom2    start2      end2 name score strand1 strand2
   1:      1 161688841 161688841      3  16468400  16468400    .   133       +       +
   2:     11  65499812  65499812     14 105644570 105644570    .    88       +       -
   3:     11  65499951  65499951     14 105644568 105644568    .   135       -       +
   4:     13  91324291  91324291     14 105745520 105745520    .    90       -       +
   5:     13  91323445  91323445     16  10886782  10886782    .    73       +       +
  ---                                                                                 
1091:      3 189537648 189537650      8 133891172 133891174    .    84       +       -
1092:      3 189537648 189537650      8 133891172 133891174    .   175       +       -
1093:      6  90175690  90175691     12  11555200  11555201    .   110       -       -
1094:      9  37363960  37363963     19  44794830  44794833    .   111       +       +
1095:      9  37364097  37364098     19  44794748  44794749    .    90       -       -
               tumour_sample_id    gene entrez partner        fusion
   1:                  FL2002T1  FCGR2B   2213   RFTN1  RFTN1-FCGR2B
   2:                 15-38154T  MALAT1 378938     IGH    IGH-MALAT1
   3:                 15-38154T  MALAT1 378938     IGH    IGH-MALAT1
   4:                 15-31924T MIR17HG      0     IGH   IGH-MIR17HG
   5:                  SP124973 MIR17HG      0   CIITA CIITA-MIR17HG
  ---                                                               
1091:                      BL41     MYC   4609    BCL6      BCL6-MYC
1092: BLGSP-71-30-00681-01A-01E     MYC   4609    BCL6      BCL6-MYC
1093:                  SP192993    ETV6   2120   BACH2    BACH2-ETV6
1094:                  SP116674    BCL3      0    PAX5     PAX5-BCL3
1095:                  SP116674    BCL3      0    PAX5     PAX5-BCL3
```