### PR TITLE
Bug fix: Allow mafs with varying column headers to be loaded without error

### DIFF
--- a/R/fread_maf.R
+++ b/R/fread_maf.R
@@ -165,7 +165,7 @@ fread_maf = function(maf_file_path,
     file = maf_file_path,
     col_types = colClasses
     ) %>%
-    dplyr::select(all_of(select_cols))
+    dplyr::select(any_of(select_cols))
 
   return(maf_df)
 }


### PR DESCRIPTION
Fixes this longstanding bug that affects loading individual mafs instead of subsetting from merge: 

```
> bl_dlbcl <- get_gambl_metadata() %>% filter(seq_type == "genome", pathology %in% c("BL", "DLBCL"), unix_group == "gambl")

> get_ssm_by_samples(these_samples_metadata = bl_dlbcl)

Error in `bind_rows()` at GAMBLR.results/R/get_ssm_by_samples.R:217:7:
! Argument 1 must be a data frame or a named atomic vector.
Run `rlang::last_trace()` to see where the error occurred.
Warning message:
In parallel::mclapply(these_sample_ids, function(x) { :
  all scheduled cores encountered errors in user code
```

This error was caused by some maf files lacking some of the column names that are hard-coded into fread_maf. 