### PR TITLE
Bug fixes + updates

### DIFF
--- a/GAMBLR_examples_output.log
+++ b/GAMBLR_examples_output.log
@@ -1,6 +1,6 @@
-[1] "=== STARTED AT 2026-02-16 11:12:35.351052 ==="
+[1] "=== STARTED AT 2026-05-27 10:58:03 ==="
 [1] "=== RUNNING devtools::run_examples() ==="
-── Running 47 example files ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── GAMBLR.utils ──
+── Running 50 example files ────────────────────────── GAMBLR.utils ──
 
 > all_sample_seg = GAMBLR.data::sample_data$grch37$seg
 
@@ -54,21 +54,21 @@
 
 > dplyr::filter(dlbcl_coding, !grepl("other", mutation_alias)) %>% 
 +     dplyr::select(Chromosome, Start_Position, Variant_Classification, 
-+         HGVSp_Short, hot_spot, mutation_alias, mutation_annotation)
++         HGVSp_Short, hot_spot, mutation_alias, driver_alias)
 genomic_data Object
 Genome Build: grch37 
 Showing first 10 rows:
-   Chromosome Start_Position Variant_Classification HGVSp_Short hot_spot mutation_alias mutation_annotation
-1           1      117113520          Splice_Region        <NA>     TRUE     CD58_trunc         CD58_driver
-2           1      203274831      Nonsense_Mutation      p.Q33*     TRUE     BTG2_trunc         BTG2_driver
-3           1      203274883          Splice_Region        <NA>     TRUE     BTG2_trunc         BTG2_driver
-4           1      203276251      Nonsense_Mutation      p.W54*     TRUE     BTG2_trunc         BTG2_driver
-5          13       41239891      Missense_Mutation     p.S153R     TRUE      FOXO1_DBD        FOXO1_driver
-6          17       62006819      Missense_Mutation     p.G190A     TRUE     CD79B_ITAM        CD79B_driver
-7           1       27023114      Nonsense_Mutation      p.Q74*     TRUE   ARID1A_trunc       ARID1A_driver
-8           1       85733609      Nonsense_Mutation     p.R135*     TRUE    BCL10_Cterm        BCL10_driver
-9           6       75974988      Nonsense_Mutation     p.R138*     TRUE  TMEM30A_trunc      TMEM30A_driver
-10         12       49438193      Nonsense_Mutation    p.Y1692*     TRUE    KMT2D_trunc        KMT2D_driver
+   Chromosome Start_Position Variant_Classification HGVSp_Short hot_spot mutation_alias  driver_alias
+1           1      117113520          Splice_Region        <NA>    FALSE     CD58_trunc   CD58_driver
+2           1      203274831      Nonsense_Mutation      p.Q33*    FALSE     BTG2_trunc   BTG2_driver
+3           1      203274883          Splice_Region        <NA>    FALSE     BTG2_trunc   BTG2_driver
+4           1      203276251      Nonsense_Mutation      p.W54*    FALSE     BTG2_trunc   BTG2_driver
+5           3      101578252                  3'UTR        <NA>    FALSE     NFKBIZ_UTR NFKBIZ_driver
+6           3      101578255                  3'UTR        <NA>    FALSE     NFKBIZ_UTR NFKBIZ_driver
+7          13       41239891      Missense_Mutation     p.S153R    FALSE      FOXO1_DBD  FOXO1_driver
+8          17       62006819      Missense_Mutation     p.G190A    FALSE     CD79B_ITAM  CD79B_driver
+9           1       27023114      Nonsense_Mutation      p.Q74*    FALSE   ARID1A_trunc ARID1A_driver
+10          1       85733609      Nonsense_Mutation     p.R135*    FALSE    BCL10_Cterm  BCL10_driver
 
 > library(GAMBLR.data)
 
@@ -130,18 +130,10 @@ Showing first 10 rows:
 
 > test <- liftover(data_df = bed, mode = "bed", target_build = "hg38")
 
-  1 
-127 
-[1] 127
-
 > maf <- GAMBLR.open::get_coding_ssm() %>% dplyr::filter(Tumor_Sample_Barcode == 
 +     "DOHH-2")
 
 > test <- liftover(data_df = maf, mode = "maf", target_build = "hg38")
-
-  1 
-234 
-[1] 234
 
 > bedpe <- GAMBLR.open::get_manta_sv(projection = "hg38")
 
@@ -174,4 +166,4 @@ Showing first 10 rows:
 
 > lymphgen = tidy_lymphgen(df = metadata, lymphgen_column_in = "lymphgen_with_cnv", 
 +     lymphgen_column_out = "lymphgen_with_cnv_tidy", relevel = TRUE)
-[1] "=== COMPLETED AT 2026-02-16 11:13:45.210218 ==="
+[1] "=== COMPLETED AT 2026-05-27 11:00:45 ==="

--- a/R/gene_to_region.R
+++ b/R/gene_to_region.R
@@ -33,127 +33,98 @@ gene_to_region = function(gene_symbol,
                           sort_regions = TRUE,
                           pad_length = 0){
 
-  stopifnot('`projection` parameter must be "grch37" or "hg38"' = projection %in% c("grch37", "hg38"))
-  stopifnot('`return_as` parameter must be "region", "bed" or "df"' = return_as %in% c("region", "bed", "df"))
-  stopifnot('One and only one of the `gene_symbol` and `ensembl_id` parameters must be given to this function' = sum(missing(gene_symbol), missing(ensembl_id)) == 1)
-
-  #set mart based on selected genome projection
-  if(projection == "grch37"){
-    gene_coordinates = GAMBLR.data::grch37_gene_coordinates
-    chr_select = paste0(c(c(1:22),"X","Y"))
-  }else{
-    gene_coordinates = GAMBLR.data::hg38_gene_coordinates
-    chr_select = paste0("chr", c(c(1:22),"X","Y"))
-  }
-
-  #filter on gene_symbol/ensembl_id
-  if(!missing(gene_symbol) && missing(ensembl_id)){
-    # If aliases are available, auto-map symbols that don't match the selected build.
-    # Expected columns: hg19, hg38 (where hg19 corresponds to grch37).
-    aliases_df = as.data.frame(aliases)
-
-    converted_symbols = character(0)
-    if(!is.null(aliases_df) && all(c("hg19", "hg38") %in% colnames(aliases_df))){
-      target_col = if(projection == "grch37") "hg19" else "hg38"
-      source_col = if(projection == "grch37") "hg38" else "hg19"
-      # Only map symbols missing from the selected build
-      missing_symbols = setdiff(gene_symbol, gene_coordinates$hugo_symbol)
-      if(length(missing_symbols) > 0){
-        map_pos = match(gene_symbol, aliases_df[[source_col]])
-        mapped = aliases_df[[target_col]][map_pos]
-        do_map = !is.na(map_pos) & gene_symbol %in% missing_symbols & !is.na(mapped) & mapped != ""
-        if(any(do_map)){
-          gene_symbol[do_map] = mapped[do_map]
-          converted_symbols = unique(aliases_df[[source_col]][map_pos[do_map]])
+  stopifnot(`\`projection\` parameter must be "grch37" or "hg38"` = projection %in% 
+        c("grch37", "hg38"))
+    stopifnot(`\`return_as\` parameter must be "region", "bed" or "df"` = return_as %in% 
+        c("region", "bed", "df"))
+    stopifnot(`One and only one of the \`gene_symbol\` and \`ensembl_id\` parameters must be given to this function` = sum(missing(gene_symbol), 
+        missing(ensembl_id)) == 1)
+    if (projection == "grch37") {
+        gene_coordinates = GAMBLR.data::grch37_gene_coordinates
+        chr_select = paste0(c(c(1:22), "X", "Y"))
+    }
+    else {
+        gene_coordinates = GAMBLR.data::hg38_gene_coordinates
+        chr_select = paste0("chr", c(c(1:22), "X", "Y"))
+    }
+    if (!missing(gene_symbol) && missing(ensembl_id)) {
+        gene_coordinates = dplyr::filter(gene_coordinates, hugo_symbol %in% 
+            gene_symbol)
+        genes_not_vailable = gene_symbol[!gene_symbol %in% gene_coordinates$hugo_symbol]
+    }
+    if (missing(gene_symbol) && !missing(ensembl_id)) {
+        gene_coordinates = dplyr::filter(gene_coordinates, ensembl_gene_id %in% 
+            ensembl_id)
+        genes_not_vailable = ensembl_id[!ensembl_id %in% gene_coordinates$ensembl_gene_id]
+    }
+    if (length(genes_not_vailable) > 0) {
+        paste(genes_not_vailable, collapse = ", ") %>% gettextf("Some input gene(s) have no region info available. They are:\n%s.", 
+            .) %>% message
+    }
+    region = dplyr::select(gene_coordinates, chromosome, start, 
+        end, gene_name, hugo_symbol, ensembl_gene_id) %>% as.data.frame() %>% 
+        dplyr::filter(chromosome %in% chr_select)
+    region = mutate(region, start = start - pad_length, end = end + 
+        pad_length)
+    if (sort_regions) {
+        if (projection == "grch37") {
+            chrm_num = region$chromosome
         }
-      }
+        else {
+            chrm_num = sub("chr", "", region$chromosome)
+        }
+        chrm_num = factor(chrm_num, levels = c(1:22, "X", "Y"), 
+            ordered = TRUE)
+        region = dplyr::arrange(region, chrm_num, start)
     }
-
-    gene = gene_symbol
-    gene_coordinates = dplyr::filter(gene_coordinates, hugo_symbol %in% gene_symbol)
-    genes_not_vailable = gene_symbol[! gene_symbol %in% gene_coordinates$hugo_symbol]
-  }
-  if(missing(gene_symbol) && !missing(ensembl_id)){
-    ensembl_gene_id = ensembl_id
-    gene = ensembl_gene_id
-    gene_coordinates = dplyr::filter(gene_coordinates, ensembl_gene_id %in% ensembl_id)
-    genes_not_vailable = ensembl_id[! ensembl_id %in% gene_coordinates$ensembl_gene_id]
-  }
-
-  #print list of genes that have no region info available
-  if(length(genes_not_vailable) > 0){
-    paste(genes_not_vailable, collapse = ", ") %>%
-      gettextf("Some input gene(s) have no region info available. They are:\n%s.", .) %>%
-      message
-  }
-
-  region = dplyr::select(gene_coordinates, chromosome, start, end, gene_name, hugo_symbol, ensembl_gene_id) %>%
-    as.data.frame() %>%
-    dplyr::filter(chromosome %in% chr_select)
-  region = mutate(region, start = start - pad_length, end = end + pad_length)
-  if(sort_regions){
-    if(projection == "grch37"){
-      chrm_num = region$chromosome
-    }else{
-      chrm_num = sub("chr", "", region$chromosome)
+    else {
+        if (!missing(gene_symbol) && missing(ensembl_id)) {
+            region = arrange(region, match(hugo_symbol, gene_symbol))
+        }
+        if (missing(gene_symbol) && !missing(ensembl_id)) {
+            region = arrange(region, match(hugo_symbol, ensembl_id))
+        }
     }
-    chrm_num = factor(chrm_num, levels = c(1:22, "X", "Y"), ordered = TRUE)
-    region = dplyr::arrange(region, chrm_num, start)
-  }else{
-    #make the output gene order the same as the input
-    if(!missing(gene_symbol) && missing(ensembl_id)){
-      gene = gene_symbol
-      region = arrange(region, match(hugo_symbol, gene_symbol))
+    region[region == ""] = NA
+    region = distinct(region, .keep_all = TRUE)
+    if (return_as == "bed") {
+        region = dplyr::select(region, chromosome, start, end, 
+            hugo_symbol)
     }
-    if(missing(gene_symbol) && !missing(ensembl_id)){
-      gene = ensembl_id
-      region = arrange(region, match(hugo_symbol, ensembl_id))
+    else if (return_as == "df") {
+        region = region
     }
-  }
-
-  region[region == ""] = NA
-  region = distinct(region, .keep_all = TRUE)
-  if(nrow(region)>1){
-    message(paste0(nrow(region), " regions returned for the provided gene", gene))
-    region = dplyr::slice_head(region, n = 1)
-  }
-  if(return_as == "bed"){
-    #return one-row data frame with first 4 standard BED columns. TODO: Ideally also include strand if we have access to it in the initial data frame
-    region = dplyr::select(region, chromosome, start, end, hugo_symbol)
-
-  }else if(return_as == "df"){
-    region = region
-
-  }else{
-    #default: return in chr:start-end format
-    if(!missing(gene_symbol) && missing(ensembl_id)){
-      ids = dplyr::pull(region, hugo_symbol)
+    else {
+        if (!missing(gene_symbol) && missing(ensembl_id)) {
+            ids = dplyr::pull(region, hugo_symbol)
+        }
+        if (missing(gene_symbol) && !missing(ensembl_id)) {
+            ids = dplyr::pull(region, ensembl_gene_id)
+        }
+        region = setNames(paste0(region$chromosome, ":", region$start, 
+            "-", region$end, recycle0 = TRUE), ids)
     }
-    if(missing(gene_symbol) && !missing(ensembl_id)){
-      ids = dplyr::pull(region, ensembl_gene_id)
+    if (return_as %in% c("bed", "df")) {
+        if (!missing(gene_symbol)) {
+            message(paste0(nrow(region[!is.na(region$chromosome), 
+                ]), " region(s) returned for ", length(gene_symbol), 
+                " gene(s)"))
+        }
+        if (!missing(ensembl_id)) {
+            message(paste0(nrow(region[!is.na(region$chromosome), 
+                ]), " region(s) returned for ", length(ensembl_id), 
+                " gene(s)"))
+        }
     }
-    region = setNames(
-      paste0(region$chromosome, ":", region$start, "-", region$end, recycle0 = TRUE),
-      ids
-    )
-  }
-
-  if(return_as %in% c("bed", "df")){
-    if(!missing(gene_symbol)){
-      message(paste0(nrow(region[!is.na(region$chromosome),]), " region(s) returned for ", length(gene_symbol), " gene(s)"))
+    else {
+        if (!missing(gene_symbol)) {
+            message(paste0(length(region[!is.na(region)]), " region(s) returned for ", 
+                length(gene_symbol), " gene(s)"))
+        }
+        if (!missing(ensembl_id)) {
+            message(paste0(length(region[!is.na(region)]), " region(s) returned for ", 
+                length(ensembl_id), " gene(s)"))
+        }
     }
-
-    if(!missing(ensembl_id)){
-      message(paste0(nrow(region[!is.na(region$chromosome),]), " region(s) returned for ", length(ensembl_id), " gene(s)"))
-    }
-  }else{
-    if(!missing(gene_symbol)){
-      message(paste0(length(region[!is.na(region)]), " region(s) returned for ", length(gene_symbol), " gene(s)"))
-    }
-
-    if(!missing(ensembl_id)){
-      message(paste0(length(region[!is.na(region)]), " region(s) returned for ", length(ensembl_id), " gene(s)"))
-    }
-  }
-  return(region)
+    return(region)
 }

--- a/R/gene_to_region.R
+++ b/R/gene_to_region.R
@@ -32,11 +32,11 @@ gene_to_region = function(gene_symbol,
                           return_as = "region",
                           sort_regions = TRUE,
                           pad_length = 0){
-  
+
   stopifnot('`projection` parameter must be "grch37" or "hg38"' = projection %in% c("grch37", "hg38"))
   stopifnot('`return_as` parameter must be "region", "bed" or "df"' = return_as %in% c("region", "bed", "df"))
   stopifnot('One and only one of the `gene_symbol` and `ensembl_id` parameters must be given to this function' = sum(missing(gene_symbol), missing(ensembl_id)) == 1)
-  
+
   #set mart based on selected genome projection
   if(projection == "grch37"){
     gene_coordinates = GAMBLR.data::grch37_gene_coordinates
@@ -45,13 +45,13 @@ gene_to_region = function(gene_symbol,
     gene_coordinates = GAMBLR.data::hg38_gene_coordinates
     chr_select = paste0("chr", c(c(1:22),"X","Y"))
   }
-  
+
   #filter on gene_symbol/ensembl_id
   if(!missing(gene_symbol) && missing(ensembl_id)){
     # If aliases are available, auto-map symbols that don't match the selected build.
     # Expected columns: hg19, hg38 (where hg19 corresponds to grch37).
     aliases_df = as.data.frame(aliases)
-    
+
     converted_symbols = character(0)
     if(!is.null(aliases_df) && all(c("hg19", "hg38") %in% colnames(aliases_df))){
       target_col = if(projection == "grch37") "hg19" else "hg38"
@@ -68,26 +68,27 @@ gene_to_region = function(gene_symbol,
         }
       }
     }
-    
+
     gene = gene_symbol
     gene_coordinates = dplyr::filter(gene_coordinates, hugo_symbol %in% gene_symbol)
     genes_not_vailable = gene_symbol[! gene_symbol %in% gene_coordinates$hugo_symbol]
   }
   if(missing(gene_symbol) && !missing(ensembl_id)){
+    ensembl_gene_id = ensembl_id
     gene = ensembl_gene_id
     gene_coordinates = dplyr::filter(gene_coordinates, ensembl_gene_id %in% ensembl_id)
     genes_not_vailable = ensembl_id[! ensembl_id %in% gene_coordinates$ensembl_gene_id]
   }
-  
+
   #print list of genes that have no region info available
   if(length(genes_not_vailable) > 0){
     paste(genes_not_vailable, collapse = ", ") %>%
       gettextf("Some input gene(s) have no region info available. They are:\n%s.", .) %>%
       message
   }
-  
+
   region = dplyr::select(gene_coordinates, chromosome, start, end, gene_name, hugo_symbol, ensembl_gene_id) %>%
-    as.data.frame() %>% 
+    as.data.frame() %>%
     dplyr::filter(chromosome %in% chr_select)
   region = mutate(region, start = start - pad_length, end = end + pad_length)
   if(sort_regions){
@@ -109,7 +110,7 @@ gene_to_region = function(gene_symbol,
       region = arrange(region, match(hugo_symbol, ensembl_id))
     }
   }
-  
+
   region[region == ""] = NA
   region = distinct(region, .keep_all = TRUE)
   if(nrow(region)>1){
@@ -119,10 +120,10 @@ gene_to_region = function(gene_symbol,
   if(return_as == "bed"){
     #return one-row data frame with first 4 standard BED columns. TODO: Ideally also include strand if we have access to it in the initial data frame
     region = dplyr::select(region, chromosome, start, end, hugo_symbol)
-    
+
   }else if(return_as == "df"){
     region = region
-    
+
   }else{
     #default: return in chr:start-end format
     if(!missing(gene_symbol) && missing(ensembl_id)){
@@ -136,12 +137,12 @@ gene_to_region = function(gene_symbol,
       ids
     )
   }
-  
+
   if(return_as %in% c("bed", "df")){
     if(!missing(gene_symbol)){
       message(paste0(nrow(region[!is.na(region$chromosome),]), " region(s) returned for ", length(gene_symbol), " gene(s)"))
     }
-    
+
     if(!missing(ensembl_id)){
       message(paste0(nrow(region[!is.na(region$chromosome),]), " region(s) returned for ", length(ensembl_id), " gene(s)"))
     }
@@ -149,7 +150,7 @@ gene_to_region = function(gene_symbol,
     if(!missing(gene_symbol)){
       message(paste0(length(region[!is.na(region)]), " region(s) returned for ", length(gene_symbol), " gene(s)"))
     }
-    
+
     if(!missing(ensembl_id)){
       message(paste0(length(region[!is.na(region)]), " region(s) returned for ", length(ensembl_id), " gene(s)"))
     }

--- a/R/liftover.R
+++ b/R/liftover.R
@@ -67,10 +67,10 @@ liftover = function(
         standard_bed = FALSE,
         verbose = FALSE
     ){
-    if(missing(mode) && "genomic_data" %in% class(data_df)){
+    if(is.null(mode) && "genomic_data" %in% class(data_df)){
         mode = class(data_df)
         mode = gsub("_data","",mode)
-        mode = intersect(mode,c("seg","maf","bed"))
+        mode = intersect(mode,c("seg","maf","bed", "bedpe"))
         message("inferred class for setting mode:", mode)
         data_df = strip_genomic_classes(data_df)
     }

--- a/R/liftover.R
+++ b/R/liftover.R
@@ -270,13 +270,17 @@ liftover = function(
             over,
             keep.extra.columns = TRUE
         )
-        print(over)
+        if(verbose){
+            print(over)
+        }
         lifted <- rtracklayer::liftOver(over, chain)
 
         lifted <- data.frame(
             lifted@unlistData
         )
-        print(lifted)
+        if(verbose){
+            print(lifted)
+        }
         if(mode=="maf"){
           lifted = lifted %>%
 
@@ -292,11 +296,8 @@ liftover = function(
             dplyr::select(all_of(colnames(data_df))) %>%
             as.data.frame()
         }else if(mode=="bed"){
+          colnames(lifted)[1:3] <- original_columns[1:3]
           lifted = lifted %>%
-
-            dplyr::rename(
-              "chrom" = "seqnames"
-            ) %>%
             dplyr::select(all_of(original_columns)) %>%
             as.data.frame()
         }


### PR DESCRIPTION
This PR:

- fixes issue with liftover in `bedpe` mode where the default argument `mode` was ignored due to be being wrapped in `missing`. Here, it is instead wrapped in `is.null` and therefore respects the default value
- fixes issue with liftover in `bed` mode where the input df bed had non-standard column names. Previously the function would only rename first column, and when the columns 2 and 3 had something other than `start` and `end` it would error out. Here, it is instead renaming the first 3 columns directly and propagates the columns names to the lifted output
- fixes issue with gene_to_region that caused the examples to error out. I have restored the previous version of this function and confirmed it reproduces the expected outputs
- examples run log update