### PR TITLE
Bump version to 1.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ gType: Package
 Package: GAMBLR.utils
 Title: Collection of functions that consist of the core functionality of
     GAMBLR
-Version: 1.3
+Version: 1.4
 Authors@R:
     person("Vladimir", "Souza", , "vsouza@bcgsc.ca", role = c("aut", "cre"))
 Description: This package is part of the Genomic Analysis of Mature B-cell


### PR DESCRIPTION
Follow-up to #81, which merged one commit before this version bump landed (`8803401`, not `18d0a2f`) -- so `master`'s `DESCRIPTION` is still `Version: 1.3` despite #81's new exported functions (`maf_column_classes()`, `expand_gene_aliases()`, `sync_genes_to_maf()`).

This matters beyond just the version number: morinlab/GAMBLR.results#127 already declares `GAMBLR.utils (>= 1.4)` in its own `DESCRIPTION`, so until this merges, that constraint is unsatisfiable against `master` and installing GAMBLR.results from this branch would fail dependency resolution.

## Test plan
- [ ] `DESCRIPTION` parses and `Version: 1.4`.
- [ ] Once merged, re-verify `remotes::install_github("morinlab/GAMBLR.results", ref = "rdmorin")` (or equivalent) resolves the `GAMBLR.utils (>= 1.4)` constraint against `master`.